### PR TITLE
Small res Related Fixes

### DIFF
--- a/teru.c
+++ b/teru.c
@@ -675,7 +675,7 @@ void *connection(void *app_ptr) {
 		req_t *new_request = read_header_helper(buffer, recv_res / sizeof(char));
 		int request_url_len = strlen(new_request->url);
 
-		// using the new_request, acceess the app to see how to handle it:
+		// using the new_request, access the app to see how to handle it:
 		hashmap__response *handler;
 		if (new_request->url[request_url_len - 1] == '/') // is not a file -- don't look for public directories
 			handler = get__hashmap(app.routes, new_request->url, "w", is_lower_hashmap_data);
@@ -702,7 +702,7 @@ void *connection(void *app_ptr) {
 			// see if there is a file in that folder that corresponds with
 			// the name of the request
 			if (!(new_request->url[request_url_len - 1] == '/') && strcmp(((listen_t *) reader->payload)->r_type, "TERU_PUBLIC") == 0) {
-				if (fsck_directory((char *) get__hashmap(app.use_settings, ((listen_t *) reader->payload)->url_wrap, new_request->url), new_request->url)) {
+				if (fsck_directory((char *) get__hashmap(app.use_settings, ((listen_t *) reader->payload)->url_wrap, ""), new_request->url)) {
 					is_public = 1;
 					break;
 				}

--- a/teru.c
+++ b/teru.c
@@ -1018,10 +1018,16 @@ int res_sendFile(res_t res, char *name) {
 			full_data_index = check_renders(r_scheme, read_line, &full_data, full_data_max, full_data_index);
 		} else {
 			strcat(full_data, read_line);
+			full_data_index += curr_line_len;
 		}
 
 		full_data[full_data_index] = '\0';
 	}
+
+
+	// if res_matches() is used, but not rendering, free
+	if (!r_scheme && res_pt->render_matches)
+		deepdestroy__hashmap(res_pt->render_matches);
 
 	if (r_scheme)
 		destroy_render_scheme(r_scheme);


### PR DESCRIPTION
This updates a couple of small bugs that were found while doing further testing. The first was when `res_matches()` was used and then not `res_render()`, which resulted in a memory leak. This was fixed by checking for the `res_match` hashmap either way. Second fix relates to accessing and checking for public directories; there was an accidental third parameter set, which has now been removed.